### PR TITLE
Fix role for Dialog component, should be dialog, not alertdialog

### DIFF
--- a/packages/solid-headless/src/components/dialog/DialogControlled.ts
+++ b/packages/solid-headless/src/components/dialog/DialogControlled.ts
@@ -92,7 +92,7 @@ export function DialogControlled<T extends ValidConstructor = 'div'>(
               DIALOG_TAG,
               {
                 id: ownerID,
-                role: 'alertdialog',
+                role: 'dialog',
                 'aria-modal': true,
                 'aria-labelledby': titleID,
                 'aria-describedby': descriptionID,

--- a/packages/solid-headless/src/components/dialog/DialogUncontrolled.ts
+++ b/packages/solid-headless/src/components/dialog/DialogUncontrolled.ts
@@ -92,7 +92,7 @@ export function DialogUncontrolled<T extends ValidConstructor = 'div'>(
               DIALOG_TAG,
               {
                 id: ownerID,
-                role: 'alertdialog',
+                role: 'dialog',
                 'aria-modal': true,
                 'aria-labelledby': titleID,
                 'aria-describedby': descriptionID,


### PR DESCRIPTION
I was using the dialog example code, then after reading https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
to better understand the accessibility requirements, I changed to use `AlertDialog`, then I got the
`<DialogOverlay> must be used inside a <Dialog>` error not understanding why I got this error. I dug into the code and understood that all the tags needs to be changed to the Alert variant, so `AlertDialogOverlay`, `AlertDialogPanel` etc.
Is there a technical difficulty of using the same components and setting the correct `role` attribute to the `DialogControlled`/`DialogUncontrolled` component? Wouldn't it be better to have only one code to maintain?
I compared the code of all those components to find there was actually no difference, excepted some import sorting.
From the documentation linked above, the only difference should be the `role`, so `role="alertdialog"` for `AlertDialog` and `role="dialog"` for the `Dialog` component. For Dialog, this is currently wrongly set to `role="alertdialog"`, this PR fixes it.
