### PR TITLE
Prevent focus start point of being applied on server side which causes rendering error

### DIFF
--- a/packages/solid-headless/src/utils/use-focus-start-point.ts
+++ b/packages/solid-headless/src/utils/use-focus-start-point.ts
@@ -15,11 +15,11 @@ class FocusStartPoint {
     if (typeof document !== 'undefined') {
       this.returnElement = document.activeElement;
       this.fsp = getFocusStartPoint();
+      onCleanup(() => {
+        this.load();
+      });
     }
 
-    onCleanup(() => {
-      this.load();
-    });
   }
 
   load() {


### PR DESCRIPTION
In some scenarios, the `onCleanup` hook from the focus start point utility was called on server side, which leads to an error due to `HTMLElement` not defined (see #22). This moves the hook to a branch that should only be run on the client.